### PR TITLE
検索結果画面から詳細画面に遷移するとアプリが落ちるバグを修正

### DIFF
--- a/app/src/main/java/jp/ac/titech/itpro/sdl/itspfug202/DetailFragmentPagerAdapter.java
+++ b/app/src/main/java/jp/ac/titech/itpro/sdl/itspfug202/DetailFragmentPagerAdapter.java
@@ -1,15 +1,18 @@
 package jp.ac.titech.itpro.sdl.itspfug202;
 
+import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 
 public class DetailFragmentPagerAdapter extends FragmentPagerAdapter {
+    Bundle bundle;
 
     private CharSequence[] tabTitles = {"詳細"};
 
-    public DetailFragmentPagerAdapter(FragmentManager fm){
+    public DetailFragmentPagerAdapter(FragmentManager fm, Bundle bundle){
         super(fm);
+        this.bundle = bundle;
     }
 
     @Override
@@ -21,7 +24,9 @@ public class DetailFragmentPagerAdapter extends FragmentPagerAdapter {
     public Fragment getItem(int position){
         switch (position){
             case 0:
-                return new DetailInformationFragment();
+                DetailInformationFragment detailInformationFragment = new DetailInformationFragment();
+                detailInformationFragment.setArguments(bundle);
+                return detailInformationFragment;
             default:
                 return null;
         }

--- a/app/src/main/java/jp/ac/titech/itpro/sdl/itspfug202/DetailInformationFragment.java
+++ b/app/src/main/java/jp/ac/titech/itpro/sdl/itspfug202/DetailInformationFragment.java
@@ -6,6 +6,9 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.TextView;
+
+import jp.ac.titech.itpro.sdl.itspfug202.model.Restaurant;
 
 public class DetailInformationFragment extends Fragment {
 
@@ -15,7 +18,15 @@ public class DetailInformationFragment extends Fragment {
     @Nullable
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState){
-        return inflater.inflate(R.layout.fragment_detail_information, container, false);
+        View view = inflater.inflate(R.layout.fragment_detail_information, container, false);
+        TextView detailName = view.findViewById(R.id.detail_shop_name);
+        TextView detailAddress = view.findViewById(R.id.detail_shop_address);
+        Restaurant restaurant = (Restaurant) getArguments().getSerializable("restaurant");
+        if(restaurant != null){
+            detailName.setText(restaurant.getName());
+            detailAddress.setText(restaurant.getAddress());
+        }
+        return view;
     }
 
     @Override

--- a/app/src/main/java/jp/ac/titech/itpro/sdl/itspfug202/RestaurantDetailActivity.java
+++ b/app/src/main/java/jp/ac/titech/itpro/sdl/itspfug202/RestaurantDetailActivity.java
@@ -21,32 +21,26 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 public class RestaurantDetailActivity extends AppCompatActivity implements Serializable {
-    private Restaurant myRestaurant;
-    private ApiService apiService;
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         Log.d("SearchResultDetail","onCreate");
         super.onCreate(savedInstanceState);
-        //Toast.makeText(this,"poi");
         setContentView(R.layout.search_result_detail);
-        TextView detailName = findViewById(R.id.detail_shop_name);
-        TextView detailAddress = findViewById(R.id.detail_shop_address);
+
+        Bundle bundle = new Bundle();
+        // SearchResultActivityからの遷移
+        Restaurant myRestaurant = (Restaurant)getIntent().getSerializableExtra("restaurant");
+        if(myRestaurant != null){
+            bundle.putSerializable("restaurant", myRestaurant);
+        }
 
         // 詳細画面の表示
-        DetailFragmentPagerAdapter adapter = new DetailFragmentPagerAdapter(getSupportFragmentManager());
+        DetailFragmentPagerAdapter adapter = new DetailFragmentPagerAdapter(getSupportFragmentManager(), bundle);
         ViewPager viewPager = findViewById(R.id.DetailviewPager);
         viewPager.setOffscreenPageLimit(1);
         viewPager.setAdapter(adapter);
-
         TabLayout tabLayout = findViewById(R.id.DetailtabLayout);
         tabLayout.setupWithViewPager(viewPager);
-
-        // SearchResultActivityからの遷移
-        myRestaurant = (Restaurant)getIntent().getSerializableExtra("restaurant");
-        if(myRestaurant != null){
-            detailName.setText(myRestaurant.getName());
-            detailAddress.setText(myRestaurant.getAddress());
-        }
 
         // MainActivityからランダムボタンでの遷移
         if(getIntent().getStringExtra("random") != null){
@@ -54,7 +48,7 @@ public class RestaurantDetailActivity extends AppCompatActivity implements Seria
                     .baseUrl(BuildConfig.API_ADDRESS)
                     .addConverterFactory(GsonConverterFactory.create())
                     .build();
-            apiService = retrofit.create(ApiService.class);
+            ApiService apiService = retrofit.create(ApiService.class);
             Call<List<Restaurant>> randomRestaurantsCall = apiService.getRandomRestaurants("");
             Log.d("Demo", "call apiService randomRestaurants");
 


### PR DESCRIPTION
大雑把にはRestaurantDetailActivityで対象のRestaurantのインスタンスをBundleの形でDetailFragmentPagerAdapterに渡し、そこからさらにDetailInformationFragmentに渡しています。
そして、Fragment内でRestaurantインスタンスの値を各Viewにセットするという流れです。