### PR TITLE
add space for scroll margin

### DIFF
--- a/app/src/main/res/layout/fragment_detail_information.xml
+++ b/app/src/main/res/layout/fragment_detail_information.xml
@@ -12,7 +12,6 @@
         android:id="@+id/scrollDetail"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_above="@id/redraw_button"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -245,6 +244,13 @@
                         android:text="@string/detail_unknown" />
                 </TableRow>
             </TableLayout>
+            <Space
+                android:id="@+id/pad_bottom"
+                android:layout_width="0dp"
+                android:layout_height="14sp"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/opening_hours_table" />
         </android.support.constraint.ConstraintLayout>
     </ScrollView>
 </RelativeLayout>


### PR DESCRIPTION
色々考えたんですが、結局しょうがないので space を足すという最悪行為をしました。
14sp は一応 default teztsize（つまり文字列1行分）だったような気がします。
`android:layout_above="@id/redraw_button"` はなんとなくいらなそうな気分になったので消しましたがダメだったら直すので言ってください。
